### PR TITLE
Fixes HTML email encoding

### DIFF
--- a/lib/mailman/eex_composer.ex
+++ b/lib/mailman/eex_composer.ex
@@ -1,9 +1,15 @@
 defmodule Mailman.EexComposer do
   @moduledoc "Provides functions for rendering from Eex template files"
 
-  def compile_text_part(_config, mode, email) when mode in [:html, :text] do
-    template = email.text
-    case email.data do
+  def compile_part(_config, :html, %{html: template, data: data}) do
+    case data do
+      %{} -> template
+      data -> EEx.eval_string template, data
+    end
+  end
+
+  def compile_part(_config, :text, %{text: template, data: data}) do
+    case data do
       %{} -> template
       data -> EEx.eval_string template, data
     end
@@ -11,10 +17,6 @@ defmodule Mailman.EexComposer do
 
   def compile_part(_config, :attachment, attachment) do
     attachment.data
-  end
-
-  def compile_part(config, mode, email) do
-    compile_text_part(config, mode, email)
   end
 end
 

--- a/test/mailman_test.exs
+++ b/test/mailman_test.exs
@@ -79,6 +79,7 @@ Pictures!
     assert email.cc   == Mailman.Render.normalize_addresses(email_with_attachments.cc)
     assert email.bcc   == Mailman.Render.normalize_addresses(email_with_attachments.bcc)
     assert email.text   == email_with_attachments.text
+    assert email.html   == email_with_attachments.html
     assert_same_attachments email, email_with_attachments
   end
 


### PR DESCRIPTION
The template was always using the text template, this updates it to use
the proper one

Closes #4