### PR TITLE
move html part after text part

### DIFF
--- a/lib/mailman/render.ex
+++ b/lib/mailman/render.ex
@@ -125,8 +125,8 @@ defmodule Mailman.Render do
 
   def compile_parts(email, composer) do
     [
-      { :html,  compile_part(:html, email, composer) },
       { :plain, compile_part(:text, email, composer) },
+      { :html,  compile_part(:html, email, composer) },
       Enum.map(email.attachments, fn(attachment) ->
         { :attachment, compile_part(:attachment, attachment, composer), attachment }
       end)


### PR DESCRIPTION
Mail.app and other clients don't display the html part. According to http://stackoverflow.com/questions/5188605/gmail-displays-plain-text-email-instead-html, parts in a multipart MIME message should be in order of increasing preference. With this change mail.app (and thunderbird) shows the html mail