### PR TITLE
Making sure empty fields are "" and not nil after parse

### DIFF
--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -12,14 +12,11 @@ defmodule Mailman.ExternalSmtpAdapter do
       tls: config.tls,
       auth: config.auth
       ]
-    Task.async fn ->
       :gen_smtp_client.send_blocking {
         email.from,
         email.to,
         message
       }, relay_config
-      { :ok, message }
-    end
   end
 
 end

--- a/lib/mailman/parsing.ex
+++ b/lib/mailman/parsing.ex
@@ -8,16 +8,16 @@ defmodule Mailman.Parsing do
   @doc "Parses given mime mail and returns Email"
   def parse(raw) do
     %Mailman.Email{
-      subject: get_header(raw, "Subject"),
-      from: get_header(raw, "From"),
-      to: get_header(raw, "To"),
-      reply_to: get_header(raw, "reply-to"),
-      cc: get_header(raw, "Cc"),
-      bcc: get_header(raw, "Bcc"),
+      subject: get_header(raw, "Subject") || "",
+      from: get_header(raw, "From") || "",
+      to: get_header(raw, "To") || "",
+      reply_to: get_header(raw, "reply-to") || "",
+      cc: get_header(raw, "Cc") || "",
+      bcc: get_header(raw, "Bcc") || "",
       attachments: get_attachments(raw),
-      html: get_html(raw),
-      text: get_text(raw),
-      delivery: get_delivery(raw)
+      html: get_html(raw) || "",
+      text: get_text(raw) || "",
+      delivery: get_delivery(raw) || ""
     }
   end
 


### PR DESCRIPTION
I am using gen_smtp to receive emails, and then forward them to others. Taking the data I got from the gen_smtp example server, and passing it to Mailman.Email.parse! seemed to work well, but when I tried to send it, I got this error:

```elixir
** (FunctionClauseError) no function clause matching in :mimemail.rfc2047_utf8_encode/3
    src/mimemail.erl:913: :mimemail.rfc2047_utf8_encode(nil, [], 0)
    src/mimemail.erl:911: :mimemail.rfc2047_utf8_encode/2
    src/mimemail.erl:735: :mimemail.encode_headers/1
    src/mimemail.erl:736: :mimemail.encode_headers/1
    src/mimemail.erl:112: :mimemail.encode/2
    lib/mailman.ex:15: Mailman.deliver/2
```

It turns out it was because the reply-to field was nil, instead of "". I fixed it in my own fork, and now it works swimmingly.