### PR TITLE
Mailman removing Async

### DIFF
--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -12,14 +12,11 @@ defmodule Mailman.ExternalSmtpAdapter do
       tls: config.tls,
       auth: config.auth
       ]
-    Task.async fn ->
       :gen_smtp_client.send_blocking {
         email.from,
         email.to,
         message
       }, relay_config
-      { :ok, message }
-    end
   end
 
 end


### PR DESCRIPTION
Just going to reopen this because I think it's quite crucial. I'd be quite open to making this a separate function, if you wanted to maintain backwards compatibility (deliver_blocking or something like that).

One of my main problems is that you return an {:ok } tuple no matter what happens to the email. I was using this with Amazon SES which has rate-limiting, if I sent more than 14 emails per second, it would just fail and throw away the rest - but I didn't know which had failed. So by changing this to sync, and managing the tasks myself (I have a little task library that deals with retrying on failure etc), it worked great. I've been sending about 500 emails per day for the last six weeks with this library :)