### PR TITLE
Apple mobileconfig MIME type, default type for unknown MIME, Path bug-fix

### DIFF
--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -302,6 +302,7 @@ defmodule Mailman.Attachment do
     { ".moov", "video/quicktime" },
     { ".mov", "video/quicktime" },
     { ".movie", "video/x-sgi-movie" },
+    { ".mobileconfig", "application/x-apple-aspen-config" },
     { ".mp2", "audio/mpeg" },
     { ".mp2", "audio/x-mpeg" },
     { ".mp2", "video/mpeg" },

--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -660,7 +660,7 @@ defmodule Mailman.Attachment do
 
   @doc "Get the attachment struct for given by path file from the file system"
   def inline(file_path) do
-    case Path.join(".", file_path) |> Path.expand |> File.read do
+    case file_path |> Path.expand |> File.read do
       { :ok, data } ->
         {
           :ok,

--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -689,7 +689,7 @@ defmodule Mailman.Attachment do
       ext == extension
     end
     case type do
-      nil -> nil
+      nil -> "application/octet-stream"
       _   -> elem(type, 1)
     end
   end

--- a/lib/mailman/render.ex
+++ b/lib/mailman/render.ex
@@ -30,6 +30,7 @@ defmodule Mailman.Render do
 
   def parameters_for({:attachment, _body, attachment}) do
     [
+      { "transfer-encoding", "base64" },
       content_type_params_for(attachment),
       disposition_for(attachment),
       disposition_params_for(attachment)
@@ -38,14 +39,15 @@ defmodule Mailman.Render do
 
   def parameters_for(_part) do
     [
-      { "content-type-params", [ { "Content-Transfer-Encoding", "quoted-printable" } ] },
+      { "transfer-encoding", "quoted-printable" },
+      { "content-type-params", [] },
       { "disposition", "inline" },
       { "disposition-params", [] }
     ]
   end
 
   def content_type_params_for(_attachment) do
-    { "content-type-params", [ { "Content-Transfer-Encoding", "base64" } ] }
+    { "content-type-params", [] }
   end
 
   def disposition_for(_attachment) do

--- a/test/attachments_test.exs
+++ b/test/attachments_test.exs
@@ -19,6 +19,7 @@ defmodule AttachmentsTest do
     assert Mailman.Attachment.mime_full_for_path("image.gif") == "image/gif"
     assert Mailman.Attachment.mime_full_for_path("image.png") == "image/png"
     assert Mailman.Attachment.mime_full_for_path("invoice.pdf") == "application/pdf"
+    assert Mailman.Attachment.mime_full_for_path("file.strange") == "application/octet-stream"
     assert Mailman.Attachment.mime_full_for_path("settings.mobileconfig") == "application/x-apple-aspen-config"
   end
 
@@ -26,6 +27,7 @@ defmodule AttachmentsTest do
     assert Mailman.Attachment.mime_type_for_path("image.gif") == "image"
     assert Mailman.Attachment.mime_type_for_path("image.png") == "image"
     assert Mailman.Attachment.mime_type_for_path("invoice.pdf") == "application"
+    assert Mailman.Attachment.mime_type_for_path("file.strange") == "application"
     assert Mailman.Attachment.mime_type_for_path("settings.mobileconfig") == "application"
   end
 
@@ -33,6 +35,7 @@ defmodule AttachmentsTest do
     assert Mailman.Attachment.mime_sub_type_for_path("image.gif") == "gif"
     assert Mailman.Attachment.mime_sub_type_for_path("image.png") == "png"
     assert Mailman.Attachment.mime_sub_type_for_path("invoice.pdf") == "pdf"
+    assert Mailman.Attachment.mime_sub_type_for_path("file.strange") == "octet-stream"
     assert Mailman.Attachment.mime_sub_type_for_path("settings.mobileconfig") == "x-apple-aspen-config"
   end
 end

--- a/test/attachments_test.exs
+++ b/test/attachments_test.exs
@@ -11,25 +11,28 @@ defmodule AttachmentsTest do
     { :error, _ } = Mailman.Attachment.inline(file_path)
   end
 
-  test "#mime_types returns the list of 646 types" do
-    assert Enum.count(Mailman.Attachment.mime_types) == 646
+  test "#mime_types returns the list of 647 types" do
+    assert Enum.count(Mailman.Attachment.mime_types) == 647
   end
 
   test "#mime_type_for_path returns proper type" do
     assert Mailman.Attachment.mime_full_for_path("image.gif") == "image/gif"
     assert Mailman.Attachment.mime_full_for_path("image.png") == "image/png"
     assert Mailman.Attachment.mime_full_for_path("invoice.pdf") == "application/pdf"
+    assert Mailman.Attachment.mime_full_for_path("settings.mobileconfig") == "application/x-apple-aspen-config"
   end
 
-  test "#mime_type_for_path returns proepr values" do
+  test "#mime_type_for_path returns proper values" do
     assert Mailman.Attachment.mime_type_for_path("image.gif") == "image"
     assert Mailman.Attachment.mime_type_for_path("image.png") == "image"
     assert Mailman.Attachment.mime_type_for_path("invoice.pdf") == "application"
+    assert Mailman.Attachment.mime_type_for_path("settings.mobileconfig") == "application"
   end
 
   test "#mime_subtype_for_path returns proepr values" do
     assert Mailman.Attachment.mime_sub_type_for_path("image.gif") == "gif"
     assert Mailman.Attachment.mime_sub_type_for_path("image.png") == "png"
     assert Mailman.Attachment.mime_sub_type_for_path("invoice.pdf") == "pdf"
+    assert Mailman.Attachment.mime_sub_type_for_path("settings.mobileconfig") == "x-apple-aspen-config"
   end
 end


### PR DESCRIPTION
Thanks for the plugin.  Here are some updates on issues we encountered.

The mime list is obviously incomplete. I am including here the support for Apple's mobileconfig profiles, but still need some thought on how to be more flexible with the mime types. Also added the support for unknown MIME types. I think it's better to let developers attach anything and just use generic MIME type if format is unrecognised.

There was no need to have the leading dot added to the file_path, since it is being expanded, and expansion takes care of the current dir dot:

iex(1)> Path.expand("tmp") == Path.expand( Path.join(".", "tmp"))
true

All tests passing.

Cheers!

UPDATE

** sorry, I made the first PR from master, and since I have to use my master in mix for my app, all changes get here. 

I encountered a bug, I would receive an attachment in email, but that attachment was still base64 encoded. The docs of genstmp / mimemail don't show it very well, but Content-Transfer-Encoding is not meant to be within "content-type-params", so resulting headers are:

Content-Type: application/x-apple-aspen-config;
	Content-Transfer-Encoding=base64

instead of: (notice indentation, and parametrization with =)

Content-Type: application/x-apple-aspen-config
Content-Transfer-Encoding: base64

