### PR TITLE
removing base64 encoding and support for disposition filename

### DIFF
--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -1,11 +1,10 @@
 defmodule Mailman.Attachment do
   @moduledoc "A struct defining an attachable file. It automatically detect the mime type based on file extension."
 
-  defstruct file_path: "",
+  defstruct file_name: "",
     mime_type: "",
     mime_sub_type: "",
     data: ""
-
 
   @mime_types [
     { ".3dm", "x-world/x-3dmf" },
@@ -659,13 +658,13 @@ defmodule Mailman.Attachment do
 
 
   @doc "Get the attachment struct for given by path file from the file system"
-  def inline(file_path) do
+  def inline(file_path, file_name \\ nil) do
     case file_path |> Path.expand |> File.read do
       { :ok, data } ->
         {
           :ok,
           %Mailman.Attachment{
-            file_path: file_path |> Path.basename,
+            file_name: file_name || Path.basename(file_path),
             mime_type: mime_type_for_path(file_path),
             mime_sub_type: mime_sub_type_for_path(file_path),
             data: data
@@ -676,8 +675,8 @@ defmodule Mailman.Attachment do
   end
 
   @doc "Get the attachment struct for given by path file from the file system and throw an error if anything goes wrong."
-  def inline!(file_path) do
-    case inline(file_path) do
+  def inline!(file_path, file_name \\ nil) do
+    case inline(file_path, file_name) do
       { :ok, attachment } -> attachment
       { :error, message } -> throw message
     end

--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -668,7 +668,7 @@ defmodule Mailman.Attachment do
             file_path: file_path |> Path.basename,
             mime_type: mime_type_for_path(file_path),
             mime_sub_type: mime_sub_type_for_path(file_path),
-            data: data |> Base.encode64
+            data: data
           }
         }
       { :error, message } -> { :error, message }

--- a/lib/mailman/parsing.ex
+++ b/lib/mailman/parsing.ex
@@ -35,7 +35,7 @@ defmodule Mailman.Parsing do
     end
     if header != nil do
       value = elem(header, 1)
-      cond do 
+      cond do
         name == "To" || name == "Cc" || name == "Bcc" -> String.split(value, ",") |> Enum.map(&String.strip(&1))
         true -> value
       end
@@ -92,7 +92,7 @@ defmodule Mailman.Parsing do
 
   def raw_to_attachement(raw_part) do
     %Mailman.Attachment{
-      file_path: filename_from_raw(raw_part),
+      file_name: filename_from_raw(raw_part),
       mime_type: get_type(raw_part),
       mime_sub_type: get_subtype(raw_part),
       data: get_raw_body(raw_part)

--- a/lib/mailman/render.ex
+++ b/lib/mailman/render.ex
@@ -55,7 +55,7 @@ defmodule Mailman.Render do
   end
 
   def disposition_params_for(attachment) do
-    { "disposition-params", [{ "filename", attachment.file_path }] }
+    { "disposition-params", [{ "filename", attachment.file_name }] }
   end
 
   def mime_type_for(parts) when is_list(parts) do

--- a/test/attachments_test.exs
+++ b/test/attachments_test.exs
@@ -11,6 +11,7 @@ defmodule AttachmentsTest do
     { :error, _ } = Mailman.Attachment.inline(file_path)
   end
 
+
   test "Attachment with a different disposition filename" do
     { :ok, attachment } = Mailman.Attachment.inline("test/data/blank.png", "another_name.png")
     assert attachment.file_name == "another_name.png"

--- a/test/attachments_test.exs
+++ b/test/attachments_test.exs
@@ -11,6 +11,12 @@ defmodule AttachmentsTest do
     { :error, _ } = Mailman.Attachment.inline(file_path)
   end
 
+  test "Attachment with a different disposition filename" do
+    { :ok, attachment } = Mailman.Attachment.inline("test/data/blank.png", "another_name.png")
+    assert attachment.file_name == "another_name.png"
+    assert is_map(attachment)
+  end
+
   test "#mime_types returns the list of 647 types" do
     assert Enum.count(Mailman.Attachment.mime_types) == 647
   end

--- a/test/mailman_test.exs
+++ b/test/mailman_test.exs
@@ -96,6 +96,14 @@ Pictures!
     assert (Mailman.TestServer.deliveries |> Enum.count) == 0
   end
 
+
+  test "Ensure attachments are encoded and decoded properly" do
+    {:ok, attachment} = "test/data/blank.png" |> Path.expand |> File.read
+    {:ok, email} = Mailman.Render.render(email_with_attachments, %Mailman.EexComposeConfig{}) |> Mailman.Parsing.parse
+    assert attachment == email.attachments |> hd |> Map.get(:data)
+  end
+
+
   def assert_same_attachments(email1, email2) do
     assert Enum.count(email1.attachments) == Enum.count(email2.attachments)
     Enum.each email1.attachments, fn(attachment) ->

--- a/test/mailman_test.exs
+++ b/test/mailman_test.exs
@@ -105,7 +105,7 @@ Pictures!
           a.mime_sub_type == attachment.mime_sub_type
       end
       assert found != nil
-      assert found.file_path == Path.basename(found.file_path)
+      assert found.file_name == Path.basename(found.file_name)
     end
   end
 


### PR DESCRIPTION
So here is the issue, no Base64 encoding is needed since underlying gen_smtp will do it for you. Like this, you base64 encode the file twice, so the attachment isn't really valid.