### PR TITLE
Sending emails with full name does not work

### DIFF
--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -13,9 +13,10 @@ defmodule Mailman.ExternalSmtpAdapter do
       auth: config.auth
       ]
       pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.from) |> Enum.at(1)
+      pure_to = Enum.map(email.to, &(Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, &1) |> Enum.at(1)))
       ret = :gen_smtp_client.send_blocking {
         pure_from,
-        email.to,
+        pure_to,
         message
       }, relay_config
       case ret do

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -12,17 +12,23 @@ defmodule Mailman.ExternalSmtpAdapter do
       tls: config.tls,
       auth: config.auth
       ]
-      pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.from) |> Enum.at(1)
-      pure_to = Enum.map(email.to, &(Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, &1) |> Enum.at(1)))
+      from_envelope_address = envelope_email(email.from)
+      to_envelope_address   = Enum.map(email.to, &(envelope_email(&1)))
       ret = :gen_smtp_client.send_blocking {
-        pure_from,
-        pure_to,
+        from_envelope_address,
+        to_envelope_address,
         message
       }, relay_config
       case ret do
         { :error, _ } -> ret
         _ -> { :ok, message }
       end
+  end
+
+
+  defp envelope_email(email_address) do
+    pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email_address) 
+      |> Enum.at(1)
   end
 
 end

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -12,8 +12,8 @@ defmodule Mailman.ExternalSmtpAdapter do
       tls: config.tls,
       auth: config.auth
       ]
-      pure_from = Regex.run(~r/<((\w*\.?)*@(\w*\.?)*)>/, email.from) |> Enum.at(1)
-      pure_to   = Regex.run(~r/<((\w*\.?)*@(\w*\.?)*)>/, email.to) |> Enum.at(1)
+      pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.from) |> Enum.at(1)
+      pure_to   = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.to) |> Enum.at(1)
       ret = :gen_smtp_client.send_blocking {
         pure_from,
         pure_to,

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -27,7 +27,7 @@ defmodule Mailman.ExternalSmtpAdapter do
 
 
   defp envelope_email(email_address) do
-    pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email_address) 
+    pure_from = Regex.run(~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/, email_address) 
       |> Enum.at(1)
   end
 

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -15,7 +15,7 @@ defmodule Mailman.ExternalSmtpAdapter do
       pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.from) |> Enum.at(1)
       ret = :gen_smtp_client.send_blocking {
         pure_from,
-        mail.to,
+        email.to,
         message
       }, relay_config
       case ret do

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -12,9 +12,11 @@ defmodule Mailman.ExternalSmtpAdapter do
       tls: config.tls,
       auth: config.auth
       ]
+      pure_from = Regex.run(~r/<((\w*\.?)*@(\w*\.?)*)>/, email.from) |> Enum.at(1)
+      pure_to   = Regex.run(~r/<((\w*\.?)*@(\w*\.?)*)>/, email.to) |> Enum.at(1)
       ret = :gen_smtp_client.send_blocking {
-        email.from,
-        email.to,
+        pure_from,
+        pure_to,
         message
       }, relay_config
       case ret do

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -13,10 +13,9 @@ defmodule Mailman.ExternalSmtpAdapter do
       auth: config.auth
       ]
       pure_from = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.from) |> Enum.at(1)
-      pure_to   = Regex.run(~r/<([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})>/, email.to) |> Enum.at(1)
       ret = :gen_smtp_client.send_blocking {
         pure_from,
-        pure_to,
+        mail.to,
         message
       }, relay_config
       case ret do


### PR DESCRIPTION
When sending emails, the email address in the envelope needs to be stripped from the full name. So, if the sender or reciepient is given as "Jim Jack j.j@test.com" only "j.j@test.com" should be given to the envelope. Otherwise, postfix won't send the email.