### PR TITLE
Error matching in gen_smtp_client

### DIFF
--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -19,6 +19,7 @@ defmodule Mailman.ExternalSmtpAdapter do
       }, relay_config
       case ret do
         { :error, _, _ } -> ret
+        { :error, _ } -> ret
         _ -> { :ok, message }
       end
   end

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -18,7 +18,7 @@ defmodule Mailman.ExternalSmtpAdapter do
         message
       }, relay_config
       case ret do
-        { :error, _ } -> ret
+        { :error, _, _ } -> ret
         _ -> { :ok, message }
       end
   end


### PR DESCRIPTION
The current error structure returned by when using `gen_smtp_client.send_blocking` can be either `{error, Type, Message}` or `{error, Reason}` [ref](https://github.com/Vagabond/gen_smtp/blob/master/src/gen_smtp_client.erl#L96). This change will match both types of errors and return the value directly. Some examples:

```
{:error, :retries_exceeded,
 {:temporary_failure, "some-relay.com", :tls_failed}}
```

```
{:error, :retries_exceeded,
 {:network_failure, "some-relay.com", {:error, :timeout}}}
```