### PR TITLE
Added deliver/3 to send CC and BCC emails

### DIFF
--- a/lib/mailman.ex
+++ b/lib/mailman.ex
@@ -15,4 +15,27 @@ defmodule Mailman do
     message = Mailman.Render.render(email, context.composer)
     Adapter.deliver(context.config, email, message)
   end
+
+  @doc "Delivers given email to all addresses and returns a list of Tasks"
+  def deliver(email, context, :send_cc_and_bcc) do
+    bcc_list = email.bcc
+    cleaned_email = %Mailman.Email{email | bcc: []}
+    message = Mailman.Render.render(cleaned_email, context.composer)
+
+    to_task = [Adapter.deliver(context.config, email, message)]
+
+    cc_tasks = email.cc |> Enum.map(fn(address) ->  
+      cc_envelope = %Mailman.Email{email | to: [address]}
+      Adapter.deliver(context.config, cc_envelope, message)
+    end)
+
+    bcc_tasks = bcc_list |> Enum.map(fn(address) ->  
+      bcc_envelope = %Mailman.Email{email | to: [address]}
+      bcc_message = %Mailman.Email{email | bcc: [address]}
+      message = Mailman.Render.render(bcc_message, context.composer)
+      Adapter.deliver(context.config, bcc_envelope, message)
+    end)
+
+    to_task ++ cc_tasks ++ bcc_tasks
+  end
 end


### PR DESCRIPTION
I noticed that some external SMTP servers (Gmail, Mandrill, Sendgrid) do not handle the CC and BCC mailing. I have added a new function `deliver/3` that takes the atom `:send_cc_and_bcc` as an optional flag. This will send emails to all addresses in the CC and BCC fields in case the mail server does not take care of this. Also the BCC field is stripped and only added in to emails that have that BCC as the destination. Included are the appropriate tests.