### PR TITLE
update to mollify Elixir 1.2 compiler warnings

### DIFF
--- a/lib/mailman.ex
+++ b/lib/mailman.ex
@@ -1,12 +1,12 @@
 defmodule Mailman do
 
-  @doc "Protocol for implementing different medium of emails delivery"
   defprotocol Adapter do
+    @moduledoc "Protocol for implementing different medium of emails delivery"
     def deliver(context, email, message)
   end
 
-  @doc "Protocol for implementing different template systems for compiling email bodies"
   defprotocol Composer do
+    @moduledoc "Protocol for implementing different template systems for compiling email bodies"
     def compile_part(config, mode, email)
   end
 

--- a/lib/mailman/parsing.ex
+++ b/lib/mailman/parsing.ex
@@ -86,8 +86,10 @@ defmodule Mailman.Parsing do
   end
 
   def get_attachments(raw) do
-    Enum.filter(content_parts(raw), &is_raw_attachement(&1)) |>
-      Enum.map &raw_to_attachement(&1)
+    raw
+    |> content_parts
+    |> Enum.filter(&is_raw_attachement(&1))
+    |> Enum.map(&raw_to_attachement(&1))
   end
 
   def raw_to_attachement(raw_part) do
@@ -108,15 +110,15 @@ defmodule Mailman.Parsing do
   end
 
   def get_type(raw) when is_tuple(raw) do
-    raw |> elem 0
+    raw |> elem(0)
   end
 
   def get_subtype(raw) when is_tuple(raw) do
-    raw |> elem 1
+    raw |> elem(1)
   end
 
   def get_raw_body(raw) when is_tuple(raw) do
-    raw |> elem 4
+    raw |> elem(4)
   end
 
   def get_html(raw) do

--- a/lib/mailman/render.ex
+++ b/lib/mailman/render.ex
@@ -94,7 +94,7 @@ defmodule Mailman.Render do
       { "reply-to", email.reply_to },
       { "Cc",  email.cc |> as_list |> normalize_addresses |> Enum.join(", ") |> as_list },
       { "Bcc", email.bcc |> as_list |> normalize_addresses |> Enum.join(", ") |> as_list }
-    ] |> Enum.filter fn(i) -> elem(i, 1) != [] end
+    ] |> Enum.filter(fn(i) -> elem(i, 1) != [] end)
   end
 
   def as_list(value) when is_list(value) do
@@ -110,7 +110,7 @@ defmodule Mailman.Render do
   end
 
   def normalize_addresses(addresses) when is_list(addresses) do
-    addresses |> Enum.map fn(address) ->
+    addresses |> Enum.map(fn(address) ->
       case address |> String.split("<") |> Enum.count > 1 do
         true -> address
         false ->
@@ -119,10 +119,10 @@ defmodule Mailman.Render do
             List.first |>
             String.split(~r/([^\w\s]|_)/) |>
             Enum.map(&String.capitalize/1) |>
-            Enum.join " "
+            Enum.join(" ")
           "#{name} <#{address}>"
       end
-    end
+    end)
   end
 
   def compile_parts(email, composer) do


### PR DESCRIPTION
Prior to this commit, when compiled with Elixir 1.2, the compiler would
generate various warnings, mostly about ambiguous parameters near `|>`.
This commit adds parens to be explicit about additional parameters when
used with `|>`. This commit also adds a few other minor changes in
response to a handful of other minor compiler warnings.