### PR TITLE
Allow setting configuration in Mix.Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ In this example we're setting up the library to use the local SMTP server create
 pid = Mailman.LocalServer.start(1234)
 ```
 
+### Configuration using Mix.Config
+
+You can pass context configuration to Mailman using Mix.Config. If you do set config field value in `Mailman.Context` struct, or if you set it to `nil`, Mailman expect to read the value from Mix.Config, generally in your `config,exs` file.
+
+Here is an example `mix.exs` file snippet for Mailman:
+
+```elixir
+config :mailman,
+  relay: "localhost",
+  port: 1025,
+  auth: :never
+```
+
 ### Defining emails
 
 The email struct is defined as:

--- a/lib/mailman.ex
+++ b/lib/mailman.ex
@@ -13,6 +13,6 @@ defmodule Mailman do
   @doc "Delivers given email and returns a Task"
   def deliver(email, context) do
     message = Mailman.Render.render(email, context.composer)
-    Adapter.deliver(context.config, email, message)
+    Adapter.deliver(Mailman.Context.get_config(context), email, message)
   end
 end

--- a/lib/mailman/context.ex
+++ b/lib/mailman/context.ex
@@ -29,7 +29,7 @@ defmodule Mailman.Context do
       port: Application.get_env(:mailman, :port, 1111),
       ssl: Application.get_env(:mailman, :ssl, false),
       tls: Application.get_env(:mailman, :tls, :never),
-      auth: Application.get_env(:mailman, :tls, :always)
+      auth: Application.get_env(:mailman, :auth, :always)
     }
   end
 

--- a/lib/mailman/context.ex
+++ b/lib/mailman/context.ex
@@ -1,5 +1,46 @@
 defmodule Mailman.Context do
   @moduledoc "Defines the configuration for both rendering and sending of messages"
  
-  defstruct config: %Mailman.TestConfig{}, composer: %Mailman.EexComposeConfig{}
+  defstruct config: nil, composer: %Mailman.EexComposeConfig{}
+
+  def get_config(context) do
+    case context.config do
+      # if config in context is nil, read it from config.exs
+      nil -> get_mix_config
+      _   -> context.config
+    end
+  end
+
+  defp get_mix_config do
+    relay = Application.get_env(:mailman, :relay)
+    port = Application.get_env(:mailman, :port)
+    case relay do
+      r when r != nil      -> mix_smtp_config relay
+      p when is_integer(p) -> mix_local_config p
+      _ -> mix_test_config
+    end
+  end
+
+  defp mix_smtp_config(relay) do
+    %Mailman.SmtpConfig{
+      relay: relay,
+      username: Application.get_env(:mailman, :username, ""),
+      password: Application.get_env(:mailman, :password, ""),
+      port: Application.get_env(:mailman, :port, 1111),
+      ssl: Application.get_env(:mailman, :ssl, false),
+      tls: Application.get_env(:mailman, :tls, :never),
+      auth: Application.get_env(:mailman, :tls, :always)
+    }
+  end
+
+  defp mix_local_config(port) do
+    %Mailman.LocalSmtpConfig{
+      port: port
+    }
+  end
+
+  defp mix_test_config do
+    %Mailman.TestConfig{}
+  end
+  
 end

--- a/lib/mailman/local_smtp_config.ex
+++ b/lib/mailman/local_smtp_config.ex
@@ -1,5 +1,5 @@
 defmodule Mailman.LocalSmtpConfig do
-  @moduledoc "Configuartion struct for the locally spawned SMTP server"
+  @moduledoc "Configuration struct for the locally spawned SMTP server"
 
   defstruct port: 2525
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Mailman.Mixfile do
       homepage_url: "https://github.com/kamilc/mailman",
       description: "Library providing a clean way of defining mailers in Elixir apps",
       package: package,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.0",
       deps: deps ]
   end


### PR DESCRIPTION
You can define from mix.config SMTP config, local SMTP or test config based on value in `config.exs`:

```elixir
config :mailman,
  relay: "localhost",
  port: 1025,
  auth: :never
```