### PR TITLE
revised get_mix_config to account for port setting

### DIFF
--- a/lib/mailman/context.ex
+++ b/lib/mailman/context.ex
@@ -14,10 +14,10 @@ defmodule Mailman.Context do
   defp get_mix_config do
     relay = Application.get_env(:mailman, :relay)
     port = Application.get_env(:mailman, :port)
-    case relay do
-      r when r != nil      -> mix_smtp_config relay
-      p when is_integer(p) -> mix_local_config p
-      _ -> mix_test_config
+    cond do
+      relay            -> mix_smtp_config relay
+      is_integer(port) -> mix_local_config port
+      true             -> mix_test_config
     end
   end
 


### PR DESCRIPTION
Hello,

Port wasn't being taken into account and therefore mix_local_config wasn't being used, the test suite seems to pass both before and after the changes? This should allow local config to be inferred by setting the port but not the relay.

Hope this is helpful.

Thanks,

Anthony