### PR TITLE
Allow explicitely setting the adapter in mix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ config :mailman,
   auth: :never
 ```
 
+You can also explicitely set the adapter. In this case, all the other options will be used when creating the adapter config:
+
+```elixir
+config :mailman,
+  adapter: MyApp.MyMailAdapter,
+  port: 1025,
+  custom_param: "something"
+```
+
 ### Defining emails
 
 The email struct is defined as:

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -1,0 +1,51 @@
+defmodule Mailman.ConfigTest do
+  use ExUnit.Case, async: true
+
+  test "defaults to test config" do
+    context = %Mailman.Context{}
+    config = Mailman.Context.get_config(context)
+    assert config == %Mailman.TestConfig{}
+  end
+
+  test "returns SMTP config if relay is given" do
+    Application.put_env(:mailman, :relay, "test")
+    Application.put_env(:mailman, :port, 2345)
+    context = %Mailman.Context{}
+
+    config = Mailman.Context.get_config(context)
+
+    assert config == %Mailman.SmtpConfig{relay: "test", port: 2345}
+
+    Application.delete_env(:mailman, :relay)
+    Application.delete_env(:mailman, :port)
+  end
+
+  test "returns local SMTP config if only port is given" do
+    Application.put_env(:mailman, :port, 1234)
+    context = %Mailman.Context{}
+
+    config = Mailman.Context.get_config(context)
+
+    assert config == %Mailman.LocalSmtpConfig{port: 1234}
+
+    Application.delete_env(:mailman, :port)
+  end
+
+  defmodule FakeAdapter do
+    defstruct some_config: "default value"
+  end
+
+  test "uses explicitely passed adapter" do
+    Application.put_env(:mailman, :adapter, FakeAdapter)
+    Application.put_env(:mailman, :some_config, "overriden value")
+    context = %Mailman.Context{}
+
+    config = Mailman.Context.get_config(context)
+
+    assert config == %FakeAdapter{some_config: "overriden value"}
+
+    Application.delete_env(:mailman, :adapter)
+    Application.delete_env(:mailman, :some_config)
+  end
+
+end


### PR DESCRIPTION
This makes it possible to set a different adapter for different environments.

This commit also includes the fix proposed in #38.

Does anyone know what the best practices are for using the application environment in tests? Is there a way to sandbox them?
It's dangerous to have to clean up what I changed in the environment in every test, and I suspect it could cause issues when running tests in parallel.