### PR TITLE
Choosed the type of config based on the given relay and port

### DIFF
--- a/lib/mailman/context.ex
+++ b/lib/mailman/context.ex
@@ -14,10 +14,10 @@ defmodule Mailman.Context do
   defp get_mix_config do
     relay = Application.get_env(:mailman, :relay)
     port = Application.get_env(:mailman, :port)
-    case relay do
-      r when r != nil      -> mix_smtp_config relay
-      p when is_integer(p) -> mix_local_config p
-      _ -> mix_test_config
+    case {relay, port} do
+      {nil, nil} ->  mix_test_config
+      {nil, port} -> mix_local_config port
+      {relay, port} -> mix_smtp_config relay
     end
   end
 


### PR DESCRIPTION
The case statement to choose type of config to load has a bug. It was loading  `LocalSmtpConfig` if the type of `relay` is an `integer`. But a `relay` can never be a `integer` unless we give it on purpose. So I changed the code to choose the config based on both `relay` and `port`.

If nothing is provided use `TestConfig`
If `port` alone is provided use `LocalSmtpConfig`
If `both` relay and port are provided use `SmtpConfig` 