### PR TITLE
Independent TestServer per calling process

### DIFF
--- a/lib/mailman/test_server.ex
+++ b/lib/mailman/test_server.ex
@@ -4,27 +4,51 @@ defmodule Mailman.TestServer do
   use GenServer
   require Logger
 
+  @doc """
+  Starts the TestServer supervisor. Provided for compatibility.
+
+  Mailman.TestServerSupervisor.start_link/0 is preferred, typically in your
+  `test_helper.exs` file.
+  """
   def start do
-    GenServer.start_link(__MODULE__, [], name: TestingSmtpServer)
+    Mailman.TestServerSupervisor.start_link
   end
 
-  def deliveries do
-    GenServer.call(TestingSmtpServer, :list)
+  def start_link(initial_state, parent_pid) do
+    GenServer.start_link(__MODULE__, {initial_state, parent_pid}, [])
   end
 
-  def register_delivery(message) do
-    GenServer.cast(TestingSmtpServer, {:push, message})
+  def deliveries, do: deliveries(self)
+  def deliveries(pid) do
+    GenServer.call(pid_for(pid), :list)
   end
 
-  def clear_deliveries do
-    GenServer.call(TestingSmtpServer, :clear_deliveries)
+  def register_delivery(message), do: register_delivery(self, message)
+  def register_delivery(pid, message) do
+    GenServer.cast(pid_for(pid), {:push, message})
   end
 
-  def start_link(state) do
-    GenServer.start_link(__MODULE__, state, [])
+  def clear_deliveries, do: clear_deliveries(self)
+  def clear_deliveries(pid) do
+    GenServer.call(pid_for(pid), :clear_deliveries)
   end
 
-  def init(state) do
+  defp pid_for(parent_pid) do
+    unless Process.alive?(parent_pid),
+      do: raise(ArgumentError, "parent pid is not alive")
+
+    case :ets.lookup(:mailman_test_servers, parent_pid) do
+      [] ->
+        {:ok, pid} = Mailman.TestServerSupervisor.start_test_server(parent_pid)
+        pid
+      [{_parent_pid, pid}] ->
+        pid
+    end
+  end
+
+  def init({state, pid}) do
+    :ets.insert(:mailman_test_servers, {pid, self})
+    Process.monitor(pid)
     {:ok, state}
   end
 
@@ -40,4 +64,8 @@ defmodule Mailman.TestServer do
     {:reply, :ok, []}
   end
 
+  def handle_info({:'DOWN', _ref, _type, remote_pid, _info}, _state) do
+    :ets.delete(:mailman_test_servers, remote_pid)
+    {:stop, :normal, []}
+  end
 end

--- a/lib/mailman/test_server_supervisor.ex
+++ b/lib/mailman/test_server_supervisor.ex
@@ -1,0 +1,20 @@
+defmodule Mailman.TestServerSupervisor do
+  use Supervisor
+
+  def start_link do
+    :ets.new(:mailman_test_servers, [:set, :public, :named_table])
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def start_test_server(parent_pid) do
+    Supervisor.start_child(__MODULE__, [parent_pid])
+  end
+
+  def init([]) do
+    children = [
+      worker(Mailman.TestServer, [[]], restart: :transient)
+    ]
+
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end

--- a/lib/mailman/testing_adapter.ex
+++ b/lib/mailman/testing_adapter.ex
@@ -2,9 +2,10 @@ defmodule Mailman.TestingAdapter do
   @moduledoc "Implementation of the testing SMTP adapter"
 
   def deliver(config, _email, message) do
+    parent = self
     Task.async fn ->
       if config.store_deliveries do
-        Mailman.TestServer.register_delivery message
+        Mailman.TestServer.register_delivery(parent, message)
       end
       { :ok, message }
     end

--- a/test/mailman_test.exs
+++ b/test/mailman_test.exs
@@ -1,11 +1,6 @@
 defmodule MailmanTest do
   use ExUnit.Case, async: true
 
-  setup_all do
-    Mailman.TestServer.start
-    :ok
-  end
-
   defmodule MyApp.Mailer do
     def deliver(email) do
       Mailman.deliver(email, config)
@@ -98,34 +93,34 @@ Pictures!
     assert MyApp.Mailer.deliver(testing_email).__struct__ == Task
   end
 
-  test "#deliver/2 returns list of Tasks if it includes :send_cc_and_bcc atom" do 
+  test "#deliver/2 returns list of Tasks if it includes :send_cc_and_bcc atom" do
     assert MyApp.Mailer.deliver(testing_email, :send_cc_and_bcc) |> is_list == true
     assert MyApp.Mailer.deliver(testing_email, :send_cc_and_bcc) |> List.first |> is_map == true
   end
 
-  test "#deliver/2 sends emails to all address in CC and BCC list" do 
+  test "#deliver/2 sends emails to all address in CC and BCC list" do
     Mailman.TestServer.clear_deliveries
     MyApp.Mailer.deliver(cc_and_bcc_testing_email, :send_cc_and_bcc)
-      |> Enum.map( fn(task) -> 
+      |> Enum.map( fn(task) ->
         Task.await task
       end)
     assert (Mailman.TestServer.deliveries |> Enum.count) == 4
   end
 
-  test "#deliver/2 redactes the BCC email from the TO message" do 
+  test "#deliver/2 redactes the BCC email from the TO message" do
     Mailman.TestServer.clear_deliveries
     MyApp.Mailer.deliver(cc_and_bcc_testing_email, :send_cc_and_bcc)
-      |> Enum.map( fn(task) -> 
+      |> Enum.map( fn(task) ->
         Task.await task
       end)
     to_email = Mailman.TestServer.deliveries |> List.last |> Mailman.Email.parse!
     assert to_email.bcc == []
   end
 
-  test "#deliver/2 adds the BCC email to a BCC receiver" do 
+  test "#deliver/2 adds the BCC email to a BCC receiver" do
     Mailman.TestServer.clear_deliveries
     MyApp.Mailer.deliver(cc_and_bcc_testing_email, :send_cc_and_bcc)
-      |> Enum.map( fn(task) -> 
+      |> Enum.map( fn(task) ->
         Task.await task
       end)
     bcc_email = Mailman.TestServer.deliveries |> List.first |> Mailman.Email.parse!
@@ -219,7 +214,7 @@ Pictures!
     {:ok, message} = Task.await(MyApp.ExternalTextMailer.deliver(
       email_with_external_text))
     email = Mailman.Email.parse! message
-    assert email.text == 
+    assert email.text ==
            EEx.eval_file(email_with_external_text.text,
                          email_with_external_text.data)
   end
@@ -238,7 +233,7 @@ Pictures!
         }
     end
   end
-  
+
   def email_with_external_html do
     %Mailman.Email{
       subject: "Hello Mailman!",
@@ -259,7 +254,7 @@ Pictures!
     {:ok, message} = Task.await(MyApp.ExternalHTMLMailer.deliver(
       email_with_external_html))
     email = Mailman.Email.parse! message
-    assert email.html == 
+    assert email.html ==
            EEx.eval_file(email_with_external_html.html,
                          email_with_external_html.data)
   end
@@ -281,7 +276,7 @@ Pictures!
         }
     end
   end
-  
+
   def email_with_template_paths do
     %Mailman.Email{
       subject: "Hello Mailman!",
@@ -297,12 +292,12 @@ Pictures!
       html: "email.html.eex"
       }
   end
-  
+
   test "should load email parts from external file based on x_file_path" do
     {:ok, message} = Task.await(MyApp.ExternalTemplatesMailer.deliver(
       email_with_template_paths))
     email = Mailman.Email.parse! message
-    assert email.html == 
+    assert email.html ==
            EEx.eval_file("test/templates/#{email_with_template_paths.html}",
                          email_with_template_paths.data)
     assert email.text ==

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Mailman.TestServerSupervisor.start_link
 ExUnit.start

--- a/test/test_server_test.exs
+++ b/test/test_server_test.exs
@@ -1,0 +1,35 @@
+defmodule Mailman.TestServerTest do
+  use ExUnit.Case, async: false
+
+  alias Mailman.TestServer
+
+  test "asynchronous calls to TestServer don't interfere with each other" do
+    tasks =
+      for i <- 1..10 do
+        Task.async(fn ->
+          TestServer.register_delivery({:test, i})
+          :timer.sleep(i * 20)
+          deliveries = TestServer.deliveries
+          {(deliveries == [{:test, i}]), i, deliveries}
+        end)
+      end
+    tasks_with_results = Task.yield_many(tasks, 5000)
+    results = Enum.map(tasks_with_results, fn {task, res} ->
+      # Shutdown the tasks that did not reply nor exit
+      res || Task.shutdown(task, :brutal_kill)
+    end)
+    for {:ok, {true_or_false, i, deliveries}} <- results do
+      assert true_or_false == true, "iteration ##{i} failed; found #{inspect deliveries}"
+    end
+  end
+
+  test "a TestServer for a particular process is destroyed after that process exits" do
+    task = Task.async(fn ->
+      TestServer.register_delivery({:test, 1})
+    end)
+    Task.await(task)
+    assert_raise ArgumentError, "parent pid is not alive", fn ->
+      TestServer.deliveries(task.pid)
+    end
+  end
+end


### PR DESCRIPTION
I found that TestServer was getting clogged with multiple messages when using async tests. This starts up a new TestServer for each calling process, so they're automatically isolated. If you're using tests that span multiple processes, you should pass the pid of the process who owns the TestServer (the one who accessed it first) to any of the TestServer functions (`deliveries`, `register_delivery`, `clear_deliveries`).

Start with Mailman.TestServerSupervisor.start_link/0. Mailman.TestServer API is nearly identical, with the exception of explicit parent process arguments (will use self() as a default).