### PR TITLE
Add email validator option

### DIFF
--- a/lib/mailman.ex
+++ b/lib/mailman.ex
@@ -2,7 +2,7 @@ defmodule Mailman do
 
   defprotocol Adapter do
     @moduledoc "Protocol for implementing different medium of emails delivery"
-    def deliver(context, email, message)
+    def deliver(context, email, message, opts \\ [])
   end
 
   defprotocol Composer do
@@ -10,32 +10,36 @@ defmodule Mailman do
     def compile_part(config, mode, email)
   end
 
-  @doc "Delivers given email and returns a Task"
-  def deliver(email, context) do
-    message = Mailman.Render.render(email, context.composer)
-    Adapter.deliver(Mailman.Context.get_config(context), email, message)
-  end
-
   @doc "Delivers given email to all addresses and returns a list of Tasks"
-  def deliver(email, context, :send_cc_and_bcc) do
+  def deliver(email, context, :send_cc_and_bcc, opts) do
     bcc_list = email.bcc
     cleaned_email = %Mailman.Email{email | bcc: []}
     message = Mailman.Render.render(cleaned_email, context.composer)
 
-    to_task = [Adapter.deliver(context.config, email, message)]
+    to_task = [Adapter.deliver(context.config, email, message, opts)]
 
-    cc_tasks = email.cc |> Enum.map(fn(address) ->  
+    cc_tasks = email.cc |> Enum.map(fn(address) ->
       cc_envelope = %Mailman.Email{email | to: [address]}
-      Adapter.deliver(context.config, cc_envelope, message)
+      Adapter.deliver(context.config, cc_envelope, message, opts)
     end)
 
-    bcc_tasks = bcc_list |> Enum.map(fn(address) ->  
+    bcc_tasks = bcc_list |> Enum.map(fn(address) ->
       bcc_envelope = %Mailman.Email{email | to: [address]}
       bcc_message = %Mailman.Email{email | bcc: [address]}
       message = Mailman.Render.render(bcc_message, context.composer)
-      Adapter.deliver(context.config, bcc_envelope, message)
+      Adapter.deliver(context.config, bcc_envelope, message, opts)
     end)
 
     to_task ++ cc_tasks ++ bcc_tasks
+  end
+
+  def deliver(email, context, :send_cc_and_bcc) do
+    deliver(email, context, :send_cc_and_bcc, [])
+  end
+
+  @doc "Delivers given email and returns a Task"
+  def deliver(email, context, opts \\ []) do
+    message = Mailman.Render.render(email, context.composer)
+    Adapter.deliver(Mailman.Context.get_config(context), email, message, opts)
   end
 end

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -36,7 +36,7 @@ defmodule Mailman.ExternalSmtpAdapter do
 
 
   defp envelope_email(email_address, validator) do
-    pure_from = Regex.run(~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/, email_address)
+    pure_from = Regex.run(validator, email_address)
       |> Enum.at(1)
   end
 

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -1,8 +1,10 @@
 defmodule Mailman.ExternalSmtpAdapter do
   @moduledoc "Adapter for sending email via external SMTP server"
 
+  @default_validator ~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/
+
   @doc "Delivers an email based on specified config"
-  def deliver(config, email, message) do
+  def deliver(config, email, message, opts \\ []) do
     relay_config = [
       relay: config.relay,
       username: config.username,
@@ -12,8 +14,14 @@ defmodule Mailman.ExternalSmtpAdapter do
       tls: config.tls,
       auth: config.auth
       ]
-    from_envelope_address = envelope_email(email.from)
-    to_envelope_address   = Enum.map(email.to, &(envelope_email(&1)))
+    validator = if opts[:validator] == nil do
+      @default_validator
+    else
+      opts[:validator]
+    end
+
+    from_envelope_address = envelope_email(email.from, validator)
+    to_envelope_address   = Enum.map(email.to, &(envelope_email(&1, validator)))
     ret = :gen_smtp_client.send_blocking {
       from_envelope_address,
       to_envelope_address,
@@ -27,10 +35,9 @@ defmodule Mailman.ExternalSmtpAdapter do
   end
 
 
-  defp envelope_email(email_address) do
-    pure_from = Regex.run(~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/, email_address) 
+  defp envelope_email(email_address, validator) do
+    pure_from = Regex.run(~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/, email_address)
       |> Enum.at(1)
   end
 
 end
-

--- a/lib/mailman/local_smtp_adapter.ex
+++ b/lib/mailman/local_smtp_adapter.ex
@@ -2,9 +2,9 @@ defmodule Mailman.LocalSmtpAdapter do
   @moduledoc "Adapter for using locally spawned SMTP server"
 
   @doc "Delivers an email through a locally running process"
-  def deliver(config, email, message) do
+  def deliver(config, email, message, opts \\ []) do
     Mailman.ExternalSmtpAdapter.deliver external_for(config),
-      email, message
+      email, message, opts
   end
 
   def external_for(config) do

--- a/lib/mailman/local_smtp_config.ex
+++ b/lib/mailman/local_smtp_config.ex
@@ -5,7 +5,7 @@ defmodule Mailman.LocalSmtpConfig do
 end
 
 defimpl Mailman.Adapter, for: Mailman.LocalSmtpConfig do
-  def deliver(config, email, message) do
-    Mailman.LocalSmtpAdapter.deliver(config, email, message)
+  def deliver(config, email, message, opts \\ []) do
+    Mailman.LocalSmtpAdapter.deliver(config, email, message, opts)
   end
 end

--- a/lib/mailman/smtp_config.ex
+++ b/lib/mailman/smtp_config.ex
@@ -12,7 +12,7 @@ defmodule Mailman.SmtpConfig do
 end
 
 defimpl Mailman.Adapter, for: Mailman.SmtpConfig do
-  def deliver(config, email, message) do
-    Mailman.ExternalSmtpAdapter.deliver(config, email, message)
+  def deliver(config, email, message, opts \\ []) do
+    Mailman.ExternalSmtpAdapter.deliver(config, email, message, opts)
   end
 end

--- a/lib/mailman/test_config.ex
+++ b/lib/mailman/test_config.ex
@@ -5,7 +5,7 @@ defmodule Mailman.TestConfig do
 end
 
 defimpl Mailman.Adapter, for: Mailman.TestConfig do
-  def deliver(config, email, message) do
-    Mailman.TestingAdapter.deliver(config, email, message)
+  def deliver(config, email, message, opts \\ []) do
+    Mailman.TestingAdapter.deliver(config, email, message, opts)
   end
 end

--- a/lib/mailman/testing_adapter.ex
+++ b/lib/mailman/testing_adapter.ex
@@ -1,7 +1,7 @@
 defmodule Mailman.TestingAdapter do
   @moduledoc "Implementation of the testing SMTP adapter"
 
-  def deliver(config, _email, message) do
+  def deliver(config, _email, message, _opts \\ []) do
     if config.store_deliveries do
       Mailman.TestServer.register_delivery message
     end

--- a/test/mailman_test.exs
+++ b/test/mailman_test.exs
@@ -89,7 +89,7 @@ Pictures!
     { :ok, _  } = Mailman.Email.parse message
   end
 
-  test "#deliver/2 returns list of Tasks if it includes :send_cc_and_bcc atom" do 
+  test "#deliver/2 returns list of Tasks if it includes :send_cc_and_bcc atom" do
     assert MyApp.Mailer.deliver(testing_email, :send_cc_and_bcc) |> is_list == true
     assert MyApp.Mailer.deliver(testing_email, :send_cc_and_bcc) |> List.first |> is_tuple == true
   end


### PR DESCRIPTION
The default email address validator does not support all valid email addresses.
This commit supports the usage of a email validator argument.
