### PR TITLE
improving config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pid = Mailman.LocalServer.start(1234)
 
 ### Configuration using Mix.Config
 
-You can pass context configuration to Mailman using Mix.Config. If you do set config field value in `Mailman.Context` struct, or if you set it to `nil`, Mailman expect to read the value from Mix.Config, generally in your `config,exs` file.
+You can pass context configuration to Mailman using Mix.Config. If you do set `config` field value in `Mailman.Context` struct, or if you set it to `nil`, Mailman expect to read the value from Mix.Config, generally in your `config,exs` file.
 
 Here is an example `mix.exs` file snippet for Mailman:
 


### PR DESCRIPTION
I put the `config` word in block quote to indicate clearly that it is an actual field name.