### PR TITLE
Improving config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pid = Mailman.LocalServer.start(1234)
 
 ### Configuration using Mix.Config
 
-You can pass context configuration to Mailman using Mix.Config. If you do set config field value in `Mailman.Context` struct, or if you set it to `nil`, Mailman expect to read the value from Mix.Config, generally in your `config.exs` file.
+You can pass context configuration to Mailman using Mix.Config. If you do set `config` field value in `Mailman.Context` struct, or if you set it to `nil`, Mailman expect to read the value from Mix.Config, generally in your `config.exs` file.
 
 Here is an example `mix.exs` file snippet for Mailman:
 

--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -95,6 +95,7 @@ defmodule Mailman.Attachment do
     { ".csh", "text/x-script.csh" },
     { ".css", "application/x-pointplus" },
     { ".css", "text/css" },
+    { ".csv", "text/csv" },
     { ".cxx", "text/plain" },
     { ".dcr", "application/x-director" },
     { ".deepv", "application/x-deepv" },


### PR DESCRIPTION
This is a small change that highlights that the word `config` is a key of context structure.
