### PR TITLE
Removed compiletime deprecations

### DIFF
--- a/lib/mailman/attachment.ex
+++ b/lib/mailman/attachment.ex
@@ -685,7 +685,7 @@ defmodule Mailman.Attachment do
 
   def attach(url, file_name \\ nil) do
     case is_valid_url(url) do
-      {:ok, uri} ->
+      {:ok, _} ->
         response = HTTPotion.get(url, [timeout: 60_000])
         case response.status_code do
           200 ->
@@ -714,7 +714,7 @@ defmodule Mailman.Attachment do
 
   def mime_full_for_path(path) do
     extension = Path.extname(path)
-    type = Enum.find mime_types, fn({ext, _}) ->
+    type = Enum.find mime_types(), fn({ext, _}) ->
       ext == extension
     end
     case type do

--- a/lib/mailman/context.ex
+++ b/lib/mailman/context.ex
@@ -6,7 +6,7 @@ defmodule Mailman.Context do
   def get_config(context) do
     case context.config do
       # if config in context is nil, read it from config.exs
-      nil -> get_mix_config
+      nil -> get_mix_config()
       _   -> context.config
     end
   end
@@ -27,7 +27,7 @@ defmodule Mailman.Context do
     cond do
       relay -> mix_smtp_config relay
       is_integer(port) -> mix_local_config port
-      true -> mix_test_config
+      true -> mix_test_config()
     end
   end
 

--- a/lib/mailman/external_smtp_adapter.ex
+++ b/lib/mailman/external_smtp_adapter.ex
@@ -28,7 +28,7 @@ defmodule Mailman.ExternalSmtpAdapter do
 
 
   defp envelope_email(email_address) do
-    pure_from = Regex.run(~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/, email_address) 
+    Regex.run(~r/([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/, email_address) 
       |> Enum.at(1)
   end
 

--- a/lib/mailman/test_server.ex
+++ b/lib/mailman/test_server.ex
@@ -15,7 +15,7 @@ defmodule Mailman.TestServer do
   @spec set_global_mode!(boolean) :: boolean
   def set_global_mode!(toggle) do
     Application.put_env(:mailman, :global_mode, toggle, persistent: true)
-    _ = deliveries
+    _ = deliveries()
     toggle
   end
 
@@ -33,17 +33,17 @@ defmodule Mailman.TestServer do
     GenServer.start_link(__MODULE__, {initial_state, parent_pid}, [])
   end
 
-  def deliveries, do: deliveries(self)
+  def deliveries, do: deliveries(self())
   def deliveries(pid) do
     GenServer.call(pid_for(pid), :list)
   end
 
-  def register_delivery(message), do: register_delivery(self, message)
+  def register_delivery(message), do: register_delivery(self(), message)
   def register_delivery(pid, message) do
     GenServer.cast(pid_for(pid), {:push, message})
   end
 
-  def clear_deliveries, do: clear_deliveries(self)
+  def clear_deliveries, do: clear_deliveries(self())
   def clear_deliveries(pid) do
     GenServer.call(pid_for(pid), :clear_deliveries)
   end
@@ -69,7 +69,7 @@ defmodule Mailman.TestServer do
   end
 
   def init({state, pid}) do
-    :ets.insert(:mailman_test_servers, {pid, self})
+    :ets.insert(:mailman_test_servers, {pid, self()})
     if is_pid(pid), do: Process.monitor(pid)
     {:ok, state}
   end

--- a/test/attachments_test.exs
+++ b/test/attachments_test.exs
@@ -18,8 +18,8 @@ defmodule AttachmentsTest do
     assert is_map(attachment)
   end
 
-  test "#mime_types returns the list of 647 types" do
-    assert Enum.count(Mailman.Attachment.mime_types) == 647
+  test "#mime_types returns the list of 648 types" do
+    assert Enum.count(Mailman.Attachment.mime_types) == 648
   end
 
   test "#mime_type_for_path returns proper type" do


### PR DESCRIPTION
Hi,

I have a go at removing a few deprecations that were present in the build with latest elixir version.

The following changes were done :

- Update the mime_types count from 647 -> 648 to get the test passing (We added one at PR #60)
- Add () on the method calls
- Removed the unused variables

Most of these deprecations are present when using

```
Erlang/OTP 19 [erts-8.2] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.3.4
```

Here is the errors that were outputted during compilation :

```
warning: variable "get_mix_config" does not exist and is being expanded to "get_mix_config()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/context.ex:9

warning: variable "mix_test_config" does not exist and is being expanded to "mix_test_config()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/context.ex:30

warning: variable "pure_from" is unused
  lib/mailman/external_smtp_adapter.ex:31

warning: variable "mime_types" does not exist and is being expanded to "mime_types()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/attachment.ex:717

warning: variable "uri" is unused
  lib/mailman/attachment.ex:688

warning: variable "deliveries" does not exist and is being expanded to "deliveries()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/test_server.ex:18

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/test_server.ex:36

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/test_server.ex:41

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/test_server.ex:46

warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  lib/mailman/test_server.ex:72
```

Thanks for looking into it !